### PR TITLE
Upgrade/blink v7.6.1 conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -520,3 +520,5 @@ source/SwiftExtension/OmnicasaNative/DerivedData/OmnicasaNative/Build/Products/D
 source/SwiftExtension/OmnicasaNative/DerivedData/OmnicasaNative/Build/Products/Debug-iphonesimulator/OmnicasaNative.swiftmodule/*
 source/SwiftExtension/OmnicasaNative/DerivedData/OmnicasaNative/Build/Products/Debug-iphonesimulator/OmnicasaNative/*
 source/SwiftExtension/OmnicasaNative/DerivedData/OmnicasaNative/Build/Products/Debug-iphonesimulator/OmnicasaNative.app/*
+.idea
+.claude

--- a/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+++ b/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
@@ -15,32 +15,33 @@
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1.1" />
-      <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.1.1" />
-      <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.1.1" />
-      <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.4.1.1" />
-      <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.4.1.1" />
-      <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.1.1" />
-      <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.9.3.2" />
-      <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.1.2" />
-      <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.8.7.2" />
-      <!-- Transitive deps from blinkid-core/blinkid-ux POMs -->
-      <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.9.0.2" />
-      <PackageReference Include="Xamarin.KotlinX.Serialization.Json.Jvm" Version="1.9.0.2" />
-      <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.2" />
-      <PackageReference Include="Square.OkHttp3" Version="5.3.2.1" />
-      <PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Android" Version="1.2.0.1" />
-      <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.1" />
-      <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.5" />
-      <!-- Pin to resolve duplicate class conflicts -->
-      <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.12.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.1.2" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.10.0.1" />
+        <!-- Transitive deps from blinkid-core/blinkid-ux POMs -->
+        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.9.0.2" />
+        <PackageReference Include="Xamarin.KotlinX.Serialization.Json.Jvm" Version="1.9.0.2" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.2" />
+        <PackageReference Include="Square.OkHttp3" Version="5.3.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Android" Version="1.2.0.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.1" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.5" />
+        <!-- Pin to resolve duplicate class conflicts -->
+        <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.2" />
     </ItemGroup>
     <ItemGroup>
-      <!-- Bind these AARs (generate C# wrappers) -->
-      <AndroidLibrary Include="blinkid-core-7.6.1.aar" />
-      <AndroidLibrary Include="blinkid-ux-7.6.1.aar" />
-      <!-- Runtime-only: include in DEX but no C# bindings -->
-      <AndroidLibrary Include="microblink-ux-1.5.0.aar" Bind="false" />
-      <AndroidLibrary Include="kotlin-parcelize-runtime-2.1.20.jar" Bind="false" />
+        <!-- Bind these AARs (generate C# wrappers) -->
+        <AndroidLibrary Include="blinkid-core-7.6.1.aar" />
+        <AndroidLibrary Include="blinkid-ux-7.6.1.aar" />
+        <!-- Runtime-only: include in DEX but no C# bindings -->
+        <AndroidLibrary Include="microblink-ux-1.5.0.aar" Bind="false" />
+        <AndroidLibrary Include="kotlin-parcelize-runtime-2.1.20.jar" Bind="false" />
     </ItemGroup>
 </Project>

--- a/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+++ b/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="Square.OkHttp3" Version="5.3.2.1" />
         <PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Android" Version="1.2.0.1" />
         <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.5" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.11    1   " />
         <!-- Pin to resolve duplicate class conflicts -->
         <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.2" />
     </ItemGroup>

--- a/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+++ b/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
@@ -15,12 +15,12 @@
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1.1" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.1.1" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.1.1" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.4.1.1" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.4.1.1" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.2.3" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.4.2.3" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.4.2.3" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.2.3" />
         <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.12.2.1" />
         <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.1.2" />
         <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.1" />

--- a/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+++ b/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="Square.OkHttp3" Version="5.3.2.1" />
         <PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Android" Version="1.2.0.1" />
         <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.11    1   " />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.1" />
         <!-- Pin to resolve duplicate class conflicts -->
         <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.2" />
     </ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only version bumps; risk is limited to potential Android runtime/build regressions from the newer AndroidX packages.
> 
> **Overview**
> Updates `Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj` to bump all CameraX (`Xamarin.AndroidX.Camera.*`) packages from `1.4.1.1` to `1.4.2.3`, and `Xamarin.AndroidX.AppCompat` from `1.7.0.5` to `1.7.1.1`.
> 
> No code changes beyond dependency version upgrades; the goal is to reduce AndroidX dependency/conflict issues alongside the `blinkid-core-7.6.1.aar` / `blinkid-ux-7.6.1.aar` integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48447e8492fa25f6b243deb7553d31ed03b67ef3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->