### PR TITLE
[Net9] Bump to net-9

### DIFF
--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/CardRecognizerExtended.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/CardRecognizerExtended.cs
@@ -27,5 +27,8 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Maui
 
         [JsonIgnore]
         public ImageSource? SignatureImage { get; set; }
+        
+        [JsonIgnore]
+        public string? ErrorMessage { get; set; }
     }
 }

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
@@ -6,6 +6,8 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<WarningsAsErrors>true</WarningsAsErrors>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
 
@@ -22,8 +24,8 @@
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.72" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.72" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.120" />
 		<PackageReference Include="System.Reactive" Version="6.0.1" />
 		<PackageReference Include="Omnicasa.Mobile.BlinkID.Shared" Version="2024.8.16.59-preview" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
@@ -19,7 +19,9 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
     /// <inheritdoc/>
     public class BlinkIDService : IBlinkIDService, IBlinkIDServiceExtended
     {
+#pragma warning disable CS8618
         private static string license;
+#pragma warning restore CS8618
         
         /// <inheritdoc/>
         public IObservable<bool> Initialize(string licenseKey)
@@ -64,7 +66,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                     if (BlinkIDInitializer.Context == null || BlinkIDInitializer.Activity == null || string.IsNullOrEmpty(license))
                     {
-                        o.OnError(new ArgumentException("Please call BlinkIDInitializer.Init"));
+                        throw new ArgumentException("Please call BlinkIDInitializer.Init");
                     }
 
                     BlinkIDHelper.Scanned += (sender, args) =>
@@ -80,11 +82,16 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                     var sdkSettings = new BlinkIdSdkSettings(license);
                     var settings = new BlinkIdScanActivitySettings(sdkSettings);
-                    var scanSettings = settings.ScanningSessionSettings.ScanningSettings;                                                                                                                                    
+                    var scanSettings = settings.ScanningSessionSettings.ScanningSettings;
+                    if (scanSettings == null || scanSettings.CroppedImageSettings == null)
+                    {
+                        throw new ArgumentException("ScanningSettings is null");
+                    }
                     scanSettings.CroppedImageSettings.ReturnFaceImage = true;                                                                                                                                                
                     scanSettings.CroppedImageSettings.ReturnDocumentImage = true;                                                                                                                                            
                     scanSettings.CroppedImageSettings.ReturnSignatureImage = true;
                     var contract = new MbBlinkIdScan();
+                    
                     var intent = contract.CreateIntent(BlinkIDInitializer.Activity, settings);
 
                     BlinkIDInitializer.BlinkIdLauncher!.Launch(intent);

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/CardRecognizerExtension.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/CardRecognizerExtension.cs
@@ -121,7 +121,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                 return null;
             }
-            catch (Exception ex)
+            catch
             {
                 return null;
             }    
@@ -131,7 +131,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
         {
             try
             {
-                if (dateResult == null)
+                if (dateResult == null || dateResult.Year == null || dateResult.Month == null || dateResult.Day == null)
                     return null;
 
 #pragma warning disable CA1416
@@ -149,6 +149,9 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
             // TODO: find a more efficient way to convert bitmap without compressing to and decompressing from JPEG
             try
             {
+                if (mBImage == null || mBImage.Bitmap == null || Bitmap.CompressFormat.Jpeg == null)
+                    return null;
+                
                 var bitmap = mBImage.Bitmap;
                 byte[] bitmapData;
                 using (var stream = new MemoryStream())
@@ -171,11 +174,14 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
             // TODO: find a more efficient way to convert bitmap without compressing to and decompressing from JPEG
             try
             {
-                var bitmap = mBImage.Bitmap;
+                if (mBImage == null || mBImage.Bitmap == null || Bitmap.CompressFormat.Jpeg == null)
+                    return null;
+                
+                var bitmap = mBImage?.Bitmap;
                 byte[] bitmapData;
                 using (var stream = new MemoryStream())
                 {
-                    bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
+                    bitmap?.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
                     bitmapData = stream.ToArray();
                 }
 

--- a/Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
+++ b/Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>true</WarningsAsErrors>
     <PackageId>Omnicasa.Mobile.BlinkID.Shared</PackageId>
     <Version>1.0.0</Version>
     <Authors>HoangQuach</Authors>
@@ -19,4 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Omnicasa.Analyzers" Version="2024.7.24.14" />
+  </ItemGroup>
 </Project>

--- a/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+++ b/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net9.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -15,26 +15,26 @@
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.12.2.1" />
-        <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.1.2" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.10.0.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.12.4.1" />
+        <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.4.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.10.0.2" />
         <!-- Transitive deps from blinkid-core/blinkid-ux POMs -->
-        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.9.0.2" />
+        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.10.0.1" />
         <PackageReference Include="Xamarin.KotlinX.Serialization.Json.Jvm" Version="1.9.0.2" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.2" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.3" />
         <PackageReference Include="Square.OkHttp3" Version="5.3.2.1" />
         <PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Android" Version="1.2.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.3" />
         <!-- Pin to resolve duplicate class conflicts -->
-        <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.3" />
     </ItemGroup>
     <ItemGroup>
         <!-- Bind these AARs (generate C# wrappers) -->

--- a/Omnicasa.Mobile.BlinkID.sln
+++ b/Omnicasa.Mobile.BlinkID.sln
@@ -27,8 +27,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.UX.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.UX.Maui.Droid.Demo", "Omnicasa.Mobile.BlinkID.UX.Maui.Droid.Demo\Omnicasa.Mobile.BlinkID.UX.Maui.Droid.Demo.csproj", "{1403E505-7785-44BF-940F-3AAC075591E4}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Interop", "Interop", "{AA58A2F0-7B63-4B6C-BAE8-AA9232F2C4C1}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.Core.Maui.Droid", "Omnicasa.Mobile.BlinkID.Core.Maui.Droid\Omnicasa.Mobile.BlinkID.Core.Maui.Droid.csproj", "{73E553C4-B0A8-4163-AF17-5C99DC69A48A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.Shared", "Omnicasa.Mobile.BlinkID.Shared\Omnicasa.Mobile.BlinkID.Shared.csproj", "{00671F01-7CC7-4EB9-B69A-B3277C4F1D8E}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades MAUI/Android dependency stack and raises Android min SDK/SupportedOSPlatformVersion, which can introduce runtime/compatibility regressions. Enforcing warnings-as-errors and added null checks may break builds or change error paths but is localized.
> 
> **Overview**
> Updates `Omnicasa.Mobile.BlinkID.Shared.Maui` and related projects for the .NET 9 / MAUI 9 stack, including bumping MAUI Controls to `9.0.120`, updating AndroidX/Camera/Kotlin dependency versions, and raising Android `SupportedOSPlatformVersion` to 26.
> 
> Tightens build quality by enabling *warnings-as-errors* in the shared projects and adding `Omnicasa.Analyzers`.
> 
> Hardens Android scanning/parsing paths with extra null checks (e.g., `ScanningSettings`/image bitmaps/date parts), switches an init failure in `ScanExtended` to throw, and adds an `ErrorMessage` field to `CardRecognizerExtended` (JSON-ignored).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf8e1b5fe0ffd8991817c5fd484ade07e2475aaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->