### PR TITLE
[Net-9] Bump alpha shared net9

### DIFF
--- a/.github/workflows/build-alpha-net10-maui.yml
+++ b/.github/workflows/build-alpha-net10-maui.yml
@@ -1,0 +1,75 @@
+name: CI-Alpha-Net10-Maui-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net10 ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="10.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.iOS.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: iOS Publish Omnicasa.Mobile.BlinkID.iOS on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid Publish Omnicasa.Mobile.BlinkID.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid UX Publish Omnicasa.Mobile.BlinkID.UX.Maui.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/.github/workflows/build-alpha-net10-shared-maui.yml
+++ b/.github/workflows/build-alpha-net10-shared-maui.yml
@@ -1,0 +1,61 @@
+name: CI-Alpha-Net10-Maui-Shared-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net10-shared ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="10.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.Maui.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared.Maui on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/.github/workflows/build-alpha-net9-maui.yml
+++ b/.github/workflows/build-alpha-net9-maui.yml
@@ -1,0 +1,75 @@
+name: CI-Alpha-Net9-Maui-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net9 ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="9.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.iOS.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: iOS Publish Omnicasa.Mobile.BlinkID.iOS on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid Publish Omnicasa.Mobile.BlinkID.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid UX Publish Omnicasa.Mobile.BlinkID.UX.Maui.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/.github/workflows/build-alpha-net9-shared-maui.yml
+++ b/.github/workflows/build-alpha-net9-shared-maui.yml
@@ -1,0 +1,61 @@
+name: CI-Alpha-Net9-Maui-Shared-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net9-shared ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="9.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.Maui.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared.Maui on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/CardRecognizerExtended.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/CardRecognizerExtended.cs
@@ -27,5 +27,8 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Maui
 
         [JsonIgnore]
         public ImageSource? SignatureImage { get; set; }
+        
+        [JsonIgnore]
+        public string? ErrorMessage { get; set; }
     }
 }

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
@@ -6,6 +6,8 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<WarningsAsErrors>true</WarningsAsErrors>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
 
@@ -22,8 +24,8 @@
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.72" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.72" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.120" />
 		<PackageReference Include="System.Reactive" Version="6.0.1" />
 		<PackageReference Include="Omnicasa.Mobile.BlinkID.Shared" Version="2024.8.16.59-preview" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
@@ -19,7 +19,9 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
     /// <inheritdoc/>
     public class BlinkIDService : IBlinkIDService, IBlinkIDServiceExtended
     {
+#pragma warning disable CS8618
         private static string license;
+#pragma warning restore CS8618
         
         /// <inheritdoc/>
         public IObservable<bool> Initialize(string licenseKey)
@@ -64,7 +66,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                     if (BlinkIDInitializer.Context == null || BlinkIDInitializer.Activity == null || string.IsNullOrEmpty(license))
                     {
-                        o.OnError(new ArgumentException("Please call BlinkIDInitializer.Init"));
+                        throw new ArgumentException("Please call BlinkIDInitializer.Init");
                     }
 
                     BlinkIDHelper.Scanned += (sender, args) =>
@@ -80,11 +82,16 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                     var sdkSettings = new BlinkIdSdkSettings(license);
                     var settings = new BlinkIdScanActivitySettings(sdkSettings);
-                    var scanSettings = settings.ScanningSessionSettings.ScanningSettings;                                                                                                                                    
+                    var scanSettings = settings.ScanningSessionSettings.ScanningSettings;
+                    if (scanSettings == null || scanSettings.CroppedImageSettings == null)
+                    {
+                        throw new ArgumentException("ScanningSettings is null");
+                    }
                     scanSettings.CroppedImageSettings.ReturnFaceImage = true;                                                                                                                                                
                     scanSettings.CroppedImageSettings.ReturnDocumentImage = true;                                                                                                                                            
                     scanSettings.CroppedImageSettings.ReturnSignatureImage = true;
                     var contract = new MbBlinkIdScan();
+                    
                     var intent = contract.CreateIntent(BlinkIDInitializer.Activity, settings);
 
                     BlinkIDInitializer.BlinkIdLauncher!.Launch(intent);

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/CardRecognizerExtension.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/CardRecognizerExtension.cs
@@ -121,7 +121,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                 return null;
             }
-            catch (Exception ex)
+            catch
             {
                 return null;
             }    
@@ -131,7 +131,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
         {
             try
             {
-                if (dateResult == null)
+                if (dateResult == null || dateResult.Year == null || dateResult.Month == null || dateResult.Day == null)
                     return null;
 
 #pragma warning disable CA1416
@@ -149,6 +149,9 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
             // TODO: find a more efficient way to convert bitmap without compressing to and decompressing from JPEG
             try
             {
+                if (mBImage == null || mBImage.Bitmap == null || Bitmap.CompressFormat.Jpeg == null)
+                    return null;
+                
                 var bitmap = mBImage.Bitmap;
                 byte[] bitmapData;
                 using (var stream = new MemoryStream())
@@ -171,11 +174,14 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
             // TODO: find a more efficient way to convert bitmap without compressing to and decompressing from JPEG
             try
             {
-                var bitmap = mBImage.Bitmap;
+                if (mBImage == null || mBImage.Bitmap == null || Bitmap.CompressFormat.Jpeg == null)
+                    return null;
+                
+                var bitmap = mBImage?.Bitmap;
                 byte[] bitmapData;
                 using (var stream = new MemoryStream())
                 {
-                    bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
+                    bitmap?.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
                     bitmapData = stream.ToArray();
                 }
 

--- a/Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
+++ b/Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>true</WarningsAsErrors>
     <PackageId>Omnicasa.Mobile.BlinkID.Shared</PackageId>
     <Version>1.0.0</Version>
     <Authors>HoangQuach</Authors>
@@ -19,4 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Omnicasa.Analyzers" Version="2024.7.24.14" />
+  </ItemGroup>
 </Project>

--- a/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+++ b/Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net9.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -15,26 +15,26 @@
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.2.3" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.12.2.1" />
-        <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.1.2" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.10.0.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Video" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Extensions" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.5.3.1" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.12.4.1" />
+        <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.4.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.10.0.2" />
         <!-- Transitive deps from blinkid-core/blinkid-ux POMs -->
-        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.9.0.2" />
+        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.10.0.1" />
         <PackageReference Include="Xamarin.KotlinX.Serialization.Json.Jvm" Version="1.9.0.2" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.2" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.3" />
         <PackageReference Include="Square.OkHttp3" Version="5.3.2.1" />
         <PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Android" Version="1.2.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.1" />
-        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.3" />
         <!-- Pin to resolve duplicate class conflicts -->
-        <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.2" />
+        <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.3" />
     </ItemGroup>
     <ItemGroup>
         <!-- Bind these AARs (generate C# wrappers) -->

--- a/Omnicasa.Mobile.BlinkID.sln
+++ b/Omnicasa.Mobile.BlinkID.sln
@@ -27,8 +27,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.UX.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.UX.Maui.Droid.Demo", "Omnicasa.Mobile.BlinkID.UX.Maui.Droid.Demo\Omnicasa.Mobile.BlinkID.UX.Maui.Droid.Demo.csproj", "{1403E505-7785-44BF-940F-3AAC075591E4}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Interop", "Interop", "{AA58A2F0-7B63-4B6C-BAE8-AA9232F2C4C1}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.Core.Maui.Droid", "Omnicasa.Mobile.BlinkID.Core.Maui.Droid\Omnicasa.Mobile.BlinkID.Core.Maui.Droid.csproj", "{73E553C4-B0A8-4163-AF17-5C99DC69A48A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omnicasa.Mobile.BlinkID.Shared", "Omnicasa.Mobile.BlinkID.Shared\Omnicasa.Mobile.BlinkID.Shared.csproj", "{00671F01-7CC7-4EB9-B69A-B3277C4F1D8E}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to new CI workflows that auto-version and publish packages to NuGet and stricter build settings (`TreatWarningsAsErrors`) plus dependency bumps that may introduce build/runtime regressions.
> 
> **Overview**
> Adds four new GitHub Actions workflows (`build-alpha-net9*` and `build-alpha-net10*`) that build MAUI projects on macOS, auto-generate an *alpha* version from date + git commit count, update `.csproj` versions, and publish the resulting NuGet packages.
> 
> Tightens compilation by enabling `TreatWarningsAsErrors`/`WarningsAsErrors` in the shared projects, bumps MAUI and AndroidX/Kotlin dependency versions (and raises Android `SupportedOSPlatformVersion` to 26), and hardens Android scanning/parsing with additional null checks and a new `CardRecognizerExtended.ErrorMessage` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ff785ce8ba7d2a24b4b515c52dca106779151ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->