### PR TITLE
MOBILE-12125 Detach Android scan handler so result isn't lost across scans

### DIFF
--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
@@ -58,25 +58,31 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
         {
             var observable = Observable.Create<CardRecognizerExtended?>(o =>
             {
+                int scanTime = 0;
+
+                // Named handler so we can detach it — the static Scanned event must not keep stale
+                // subscribers, or a previous scan's dead observer runs first and swallows this result.
+                EventHandler<object?> handler = null!;
+                handler = (sender, args) =>
+                {
+                    var card = args?.ParseExtended();
+                    o.OnNext(card);
+
+                    if (++scanTime == limit)
+                    {
+                        BlinkIDHelper.Scanned -= handler;
+                        o.OnCompleted();
+                    }
+                };
+
                 try
                 {
-                    int scanTime = 0;
-
                     if (BlinkIDInitializer.Context == null || BlinkIDInitializer.Activity == null || string.IsNullOrEmpty(license))
                     {
                         o.OnError(new ArgumentException("Please call BlinkIDInitializer.Init"));
                     }
 
-                    BlinkIDHelper.Scanned += (sender, args) =>
-                    {
-                        var card = args?.ParseExtended();
-                        o.OnNext(card);
-                        
-                        if (++scanTime == limit)
-                        {
-                            o.OnCompleted();
-                        }
-                    };
+                    BlinkIDHelper.Scanned += handler;
 
                     var sdkSettings = new BlinkIdSdkSettings(license);
                     var settings = new BlinkIdScanActivitySettings(sdkSettings);
@@ -96,6 +102,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                 return Disposable.Create(() =>
                 {
+                    BlinkIDHelper.Scanned -= handler;
                 });
             });
 


### PR DESCRIPTION
## Problem
On Android, `IBlinkIDServiceExtended.ScanExtended` delivers the scan result through the **static** multicast event `BlinkIDHelper.Scanned`, but subscribed with an anonymous handler and an **empty** `Disposable.Create(() => { })` — so the handler is **never detached**.

Handlers accumulate across every scan in the app's lifetime. `BlinkIDHelper.OnActivityResult` invokes the whole chain in registration order; stale handlers (with already-completed/disposed observers) run first, and a dead observer ahead of the live one swallows/aborts delivery. Result: scanner opens, scans, closes, but the current subscriber's `OnNext` never fires — the caller gets no result.

This is why a scan launched from a transient page (e.g. the person editor → Add ID card → Scan) returns nothing, while the always-alive Person tab works, and iOS works (it uses a **per-scan** delegate, not a shared static event).

## Fix
Name the handler and detach it with `BlinkIDHelper.Scanned -= handler` on completion (limit reached) and on subscription dispose. Android-only; iOS unchanged.

## Verification
`Omnicasa.Mobile.BlinkID.Shared.Maui` builds clean for `net9.0-android` (0 errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Android-only lifecycle fix around event subscription cleanup; no auth, data model, or API surface changes.
> 
> **Overview**
> Fixes Android **ID scan results not reaching the caller** when scanning from short-lived flows (e.g. person editor), while scans from long-lived UI still worked.
> 
> `ScanExtended` now uses a **named** `BlinkIDHelper.Scanned` handler instead of an anonymous one, and **unsubscribes** when the scan limit is hit and when the Rx subscription is disposed. Previously handlers piled up on the static event and older, completed observers could run first and block delivery to the active scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e029de25b9c7a2dfaf9dd6dd66db6197cf465ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->