### PR TITLE
MOBILE-12125 Publish Maui.Shared with Android scan-handler fix

### DIFF
--- a/.github/workflows/build-alpha-net10-maui.yml
+++ b/.github/workflows/build-alpha-net10-maui.yml
@@ -1,0 +1,75 @@
+name: CI-Alpha-Net10-Maui-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net10 ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="10.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.iOS.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: iOS Publish Omnicasa.Mobile.BlinkID.iOS on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid Publish Omnicasa.Mobile.BlinkID.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid UX Publish Omnicasa.Mobile.BlinkID.UX.Maui.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/.github/workflows/build-alpha-net10-shared-maui.yml
+++ b/.github/workflows/build-alpha-net10-shared-maui.yml
@@ -1,0 +1,61 @@
+name: CI-Alpha-Net10-Maui-Shared-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net10-shared ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="10.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.Maui.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared.Maui on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/.github/workflows/build-alpha-net9-maui.yml
+++ b/.github/workflows/build-alpha-net9-maui.yml
@@ -1,0 +1,75 @@
+name: CI-Alpha-Net9-Maui-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net9 ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="9.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.iOS.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: iOS Publish Omnicasa.Mobile.BlinkID.iOS on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.iOS/Omnicasa.Mobile.BlinkID.Maui.iOS.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid Publish Omnicasa.Mobile.BlinkID.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Maui.Droid/Omnicasa.Mobile.BlinkID.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: Droid UX Publish Omnicasa.Mobile.BlinkID.UX.Maui.Droid on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.UX.Maui.Droid/Omnicasa.Mobile.BlinkID.UX.Maui.Droid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/.github/workflows/build-alpha-net9-shared-maui.yml
+++ b/.github/workflows/build-alpha-net9-shared-maui.yml
@@ -1,0 +1,61 @@
+name: CI-Alpha-Net9-Maui-Shared-Nuget
+
+on:
+  pull_request:
+    branches: [ alpha-net9-shared ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET tools
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install .NET MAUI
+        run: dotnet workload install maui
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          DATE=$(date +'%Y.%m%d')
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          VERSION="9.$DATE.$BUILD_NUMBER-alpha"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: Set Omnicasa.Mobile.BlinkID.Shared.Maui.csproj version
+        uses: Thundernerd/dotnet-project-version-updater@v1.2
+        with:
+          file: "Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj"
+          version: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared.Maui on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared.Maui/Omnicasa.Mobile.BlinkID.Shared.Maui.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}
+
+      - name: MAUI Publish Omnicasa.Mobile.BlinkID.Shared on version change
+        uses: linch90/publish-nuget@v1.0.2
+        with:
+          PROJECT_FILE_PATH: Omnicasa.Mobile.BlinkID.Shared/Omnicasa.Mobile.BlinkID.Shared.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          VERSION_STATIC: ${{ env.VERSION }}

--- a/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
+++ b/Omnicasa.Mobile.BlinkID.Shared.Maui/Platforms/Android/BlinkIDService.cs
@@ -58,25 +58,31 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
         {
             var observable = Observable.Create<CardRecognizerExtended?>(o =>
             {
+                int scanTime = 0;
+
+                // Named handler so we can detach it — the static Scanned event must not keep stale
+                // subscribers, or a previous scan's dead observer runs first and swallows this result.
+                EventHandler<object?> handler = null!;
+                handler = (sender, args) =>
+                {
+                    var card = args?.ParseExtended();
+                    o.OnNext(card);
+
+                    if (++scanTime == limit)
+                    {
+                        BlinkIDHelper.Scanned -= handler;
+                        o.OnCompleted();
+                    }
+                };
+
                 try
                 {
-                    int scanTime = 0;
-
                     if (BlinkIDInitializer.Context == null || BlinkIDInitializer.Activity == null || string.IsNullOrEmpty(license))
                     {
                         o.OnError(new ArgumentException("Please call BlinkIDInitializer.Init"));
                     }
 
-                    BlinkIDHelper.Scanned += (sender, args) =>
-                    {
-                        var card = args?.ParseExtended();
-                        o.OnNext(card);
-                        
-                        if (++scanTime == limit)
-                        {
-                            o.OnCompleted();
-                        }
-                    };
+                    BlinkIDHelper.Scanned += handler;
 
                     var sdkSettings = new BlinkIdSdkSettings(license);
                     var settings = new BlinkIdScanActivitySettings(sdkSettings);
@@ -96,6 +102,7 @@ namespace Omnicasa.Mobile.BlinkID.Shared.Droid
 
                 return Disposable.Create(() =>
                 {
+                    BlinkIDHelper.Scanned -= handler;
                 });
             });
 


### PR DESCRIPTION
Fast-forwards `alpha-shared` to `alpha` (includes #33) to trigger `build-alpha-shared-maui.yml` and publish a new `Omnicasa.Mobile.BlinkID.Maui.Shared` package (net9 android+ios) that detaches the Android scan handler so ID-card results are no longer swallowed by stale scans.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The scan-handler change affects core Android document-scan behavior; the new workflows can publish alpha packages to nuget.org when triggered on the target branches.
> 
> **Overview**
> Fixes Android **ID scan results being lost** when `ScanExtended` runs more than once by using a named `BlinkIDHelper.Scanned` handler that is unsubscribed when the scan limit is reached and when the Rx subscription is disposed, so stale observers no longer consume the next scan.
> 
> Adds **four GitHub Actions workflows** that build and publish alpha NuGet packages on `macos-latest` for `alpha-net9` / `alpha-net10` (platform iOS, Droid, UX Droid) and `alpha-net9-shared` / `alpha-net10-shared` (`Omnicasa.Mobile.BlinkID.Shared` and `.Shared.Maui`), with date/commit-based `*-alpha` versions and `NUGET_API_KEY` publish to nuget.org.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1ba421bd210632249907566a76ef7583f9d83e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->